### PR TITLE
Pinned Task symbol moved to separate column

### DIFF
--- a/tasks/static/tasks/css/style.css
+++ b/tasks/static/tasks/css/style.css
@@ -7,7 +7,7 @@
   }
 
   .task-table-name {
-    width: 60%;
+    width: 55%;
   }
 
   .claim-info {
@@ -23,6 +23,10 @@
   margin: 0;
   padding: 5%;
   background-color: #8eaebd;
+}
+
+.task-pinned {
+  width: 5%;
 }
 
 .task-table-name {

--- a/tasks/static/tasks/js/date_to_age.js
+++ b/tasks/static/tasks/js/date_to_age.js
@@ -1,5 +1,5 @@
 var scriptTag = document.getElementsByTagName('script')
-var target = scriptTag[scriptTag.length - 1].parentNode.children[6]
+var target = scriptTag[scriptTag.length - 1].parentNode.children[7]
 
 var publishDate = document.currentScript.getAttribute('task-publish-date')
 var dateDifference = Math.abs(new Date(publishDate).getTime() - new Date().getTime())

--- a/tasks/static/tasks/js/size_int_to_str.js
+++ b/tasks/static/tasks/js/size_int_to_str.js
@@ -1,5 +1,5 @@
 var scriptTag = document.getElementsByTagName('script')
-var target = scriptTag[scriptTag.length - 1].parentNode.children[5]
+var target = scriptTag[scriptTag.length - 1].parentNode.children[6]
 
 var intSize = target.innerHTML
 var size

--- a/tasks/templates/tasks/index.html
+++ b/tasks/templates/tasks/index.html
@@ -45,9 +45,9 @@
 						{{ task.deadline_date }}
 						<script>
 							if ('{{ task.deadline_date }}' === '{{ task.publish_date }}') {
-							var tt = document.getElementsByClassName('task-table-deadline');
-							var td = tt[tt.length-1];
-							td.innerHTML = 'None';
+							var taskDeadlines = document.getElementsByClassName('task-table-deadline');
+							var taskData = taskDeadlines[taskDeadlines.length-1];
+							taskData.innerHTML = 'None';
 						}
 						</script>
 					</td>

--- a/tasks/templates/tasks/index.html
+++ b/tasks/templates/tasks/index.html
@@ -27,6 +27,7 @@
 			</table>
 			<table class="task-table">
 				<tr>
+                                        <th class="task-pinned"></th>
 					<th class="task-table-name">Name</th>
 					<th class="task-table-priority">Priority</th>
 					<th class="task-table-deadline">Deadline</th>
@@ -37,7 +38,8 @@
 				{% for task in tasks %}
 				{% if task.task_open %}
 				<tr id="{{ task.id }}" class="open-task">
-					<td class="task-table-name" onclick = "show_modal('task_data', '{{ task.id }}')">{% if task.is_pinned %}<span class="bump-star">★</span> {% endif %}{{ task.task_name }}</td>
+                                        <td class="task-pinned">{% if task.is_pinned %}<span class="bump-star">★</span> {% endif %}</td>
+					<td class="task-table-name" onclick = "show_modal('task_data', '{{ task.id }}')">{{ task.task_name }}</td>
 					<td class="task-description" style="display: none">{{ task.task_description }}</td>
 					<td class="task-owner" style="display: none">{{ task.task_owner }}</td>
 					<td class="task-table-priority" onclick = "show_modal('task_data', '{{ task.id }}')">{{ task.task_priority }}</td>


### PR DESCRIPTION
Pinned task symbol moved to separate column within the table of open tasks.
When placed in the name column, the symbol would appear off-line with the rest of the text due to its larger size